### PR TITLE
Decode directly from bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,23 @@ pipenv install mcap-ros1-support
 ## Example Usage
 
 ```python
+# Reading from a strean
 from mcap.mcap0.stream_reader import StreamReader
 from mcap_ros1.decoder import Ros1Decoder
 
 reader = StreamReader("my_data.mcap")
 decoder = Ros1Decoder(reader)
 for topic, record, message in decoder.messages:
+    print(message)
+```
+
+```python
+# Reading from raw mcap data
+from mcap.mcap0.stream_reader import StreamReader
+from mcap_ros1.decoder import Ros1Decoder
+
+data = open("my_data.mcap", "rb").read()
+for topic, record, message in Ros1Decoder(data).messages:
     print(message)
 ```
 

--- a/mcap_ros1/ros1_decoder.py
+++ b/mcap_ros1/ros1_decoder.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict
+from io import BytesIO, RawIOBase
+from typing import Any, Dict, Union, cast
 
 from genpy import dynamic  # type: ignore
 from mcap.mcap0.exceptions import McapError
@@ -7,8 +8,11 @@ from mcap.mcap0.stream_reader import StreamReader
 
 
 class Ros1Decoder:
-    def __init__(self, reader: StreamReader):
-        self.__reader = reader
+    def __init__(self, source: Union[bytes, StreamReader]):
+        if isinstance(source, StreamReader):
+            self.__reader = source
+        else:
+            self.__reader = StreamReader(cast(RawIOBase, BytesIO(source)))
 
     @property
     def messages(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mcap-ros1-support
-version = 0.0.5
+version = 0.0.6
 description = ROS1 support for the Python MCAP library
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_ros_decoder.py
+++ b/tests/test_ros_decoder.py
@@ -4,9 +4,16 @@ from mcap_ros1.ros1_decoder import Ros1Decoder
 from .generate import generate_sample_data
 
 
-def test_ros_decoder():
+def test_ros_decoder_from_stream():
     with generate_sample_data() as m:
         stream_reader = StreamReader(m)
         ros_reader = Ros1Decoder(stream_reader)
         messages = [m for m in ros_reader.messages]
+        assert len(messages) == 10
+
+
+def test_ros_decoder_from_bytes():
+    with generate_sample_data() as m:
+        data = m.read()
+        messages = [m for m in Ros1Decoder(data).messages]
         assert len(messages) == 10


### PR DESCRIPTION
**Public-Facing Changes**
This allows the decoder to optionally accept raw mcap bytes directly as input, streamlining the API a bit.

<!-- link relevant GitHub issues -->
