### PR TITLE
Rename decoder class

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -526,11 +526,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:b555252a95bbb2a37a97b5ac2eb050c436f7989993565f5e0c9128fcaacadd0e",
-                "sha256:f1089d218cfcc63a212c42896f1b7fbf096874d045e1988186861a1a87d27b47"
+                "sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63",
+                "sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea"
             ],
             "index": "pypi",
-            "version": "==7.1.0"
+            "version": "==7.1.1"
         },
         "tomli": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ pipenv install mcap-ros1-support
 ```python
 # Reading from a strean
 from mcap.mcap0.stream_reader import StreamReader
-from mcap_ros1.decoder import Ros1Decoder
+from mcap_ros1.decoder import Decoder
 
 reader = StreamReader("my_data.mcap")
-decoder = Ros1Decoder(reader)
+decoder = Decoder(reader)
 for topic, record, message in decoder.messages:
     print(message)
 ```
@@ -26,10 +26,10 @@ for topic, record, message in decoder.messages:
 ```python
 # Reading from raw mcap data
 from mcap.mcap0.stream_reader import StreamReader
-from mcap_ros1.decoder import Ros1Decoder
+from mcap_ros1.decoder import Decoder
 
 data = open("my_data.mcap", "rb").read()
-for topic, record, message in Ros1Decoder(data).messages:
+for topic, record, message in Decoder(data).messages:
     print(message)
 ```
 

--- a/mcap_ros1/decoder.py
+++ b/mcap_ros1/decoder.py
@@ -7,7 +7,7 @@ from mcap.mcap0.records import Channel, Message, Schema
 from mcap.mcap0.stream_reader import StreamReader
 
 
-class Ros1Decoder:
+class Decoder:
     def __init__(self, source: Union[bytes, StreamReader]):
         if isinstance(source, StreamReader):
             self.__reader = source

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mcap-ros1-support
-version = 0.0.6
+version = 0.0.7
 description = ROS1 support for the Python MCAP library
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_ros_decoder.py
+++ b/tests/test_ros_decoder.py
@@ -1,13 +1,15 @@
+from io import RawIOBase
+from typing import cast
 from mcap.mcap0.stream_reader import StreamReader
-from mcap_ros1.ros1_decoder import Ros1Decoder
+from mcap_ros1.decoder import Decoder
 
 from .generate import generate_sample_data
 
 
 def test_ros_decoder_from_stream():
     with generate_sample_data() as m:
-        stream_reader = StreamReader(m)
-        ros_reader = Ros1Decoder(stream_reader)
+        stream_reader = StreamReader(cast(RawIOBase, m))
+        ros_reader = Decoder(stream_reader)
         messages = [m for m in ros_reader.messages]
         assert len(messages) == 10
 
@@ -15,5 +17,5 @@ def test_ros_decoder_from_stream():
 def test_ros_decoder_from_bytes():
     with generate_sample_data() as m:
         data = m.read()
-        messages = [m for m in Ros1Decoder(data).messages]
+        messages = [m for m in Decoder(data).messages]
         assert len(messages) == 10


### PR DESCRIPTION
**Public-Facing Changes**
Rename the decoder class to follow convention in the mcap-protobuf-support library

<!-- link relevant GitHub issues -->
